### PR TITLE
Fix Android "Work Profiles" also known as AfW 'Android for Work'

### DIFF
--- a/overlay/common/packages/apps/ManagedProvisioning/res/values/vendor_required_apps_managed_profile.xml
+++ b/overlay/common/packages/apps/ManagedProvisioning/res/values/vendor_required_apps_managed_profile.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources>
+    <!-- A list of apps to be retained in the managed profile by a particular vendor.
+            Takes precedence over the disallowed apps lists. -->
+    <string-array name="vendor_required_apps_managed_profile">
+        <item>com.android.vending</item> <!-- Google Play -->
+        <item>com.google.android.gms</item> <!-- Required by Play -->
+        <item>com.android.contacts</item> <!-- AOSP Contacts -->
+    </string-array>
+</resources>


### PR DESCRIPTION
Android for Work (AfW) has 'Work Profiles' that allow separated profiles
to be created so employers can allow employees to have work e-mail on
their phones (for example).

To work properly the 'ManagedProvisioning' module needs to have a proper
set of vendor required apps specified in the
'vendor_required_apps_managed_profile.xml' file.  This is the task of the
OEM so that they can specify which apps will replace stock apps.  This is
the reason why the stock AOSP code is blank.

There is a set of minimum defaults needed as specified in Android documentation:
https://source.android.com/devices/tech/admin/implement#required_apps
(They give an example from a Nexus phone)

With the default set apps correctly specified Google's open source test code
'Test DPC' should be able to complete successfully.

https://github.com/googlesamples/android-testdpc/
(Also available on Google Play:  Example code distributed by
Google to help developers implement)

The changes contained here allow LineageOS to successfully create a
'Work Profile' with 'Test DPC'.

Change-Id: I6b8ccb53149e9070712eac329e44f6c72f812410
(cherry picked from commit ac0cb02076386aff20c0af164845a89308b4dff9)